### PR TITLE
Use get_object before accessing card tweens

### DIFF
--- a/src/core/CardTemplate.gd
+++ b/src/core/CardTemplate.gd
@@ -1998,15 +1998,14 @@ func _organize_attachments() -> void:
 
 			# We don't want to try and move it if it's still tweening.
 			# But if it isn't, we make sure it always follows its parent is_running()
-			if not (card._tween.is_running()) and \
-					card.state in \
-					[CardState.ON_PLAY_BOARD,CardState.FOCUSED_ON_BOARD]:
-				card.global_position = global_position + \
-						Vector2(
-						(attach_index + 1) * card_size.x
-						* CFConst.ATTACHMENT_OFFSET[attachment_offset].x,
-						(attach_index + 1) * card_size.y \
-						* CFConst.ATTACHMENT_OFFSET[attachment_offset].y)
+			var tween : Tween = card._tween.get_object()
+			if (not (tween and tween.is_running())
+				and card.state in [CardState.ON_PLAY_BOARD,CardState.FOCUSED_ON_BOARD]
+				):
+				card.global_position = (global_position +
+					Vector2(
+						(attach_index + 1) * card_size.x * CFConst.ATTACHMENT_OFFSET[attachment_offset].x,
+						(attach_index + 1) * card_size.y * CFConst.ATTACHMENT_OFFSET[attachment_offset].y))
 
 # Returns the global mouse position but ensures it does not exit the
 # viewport limits when including the card rect

--- a/src/custom/CGFBoard.gd
+++ b/src/custom/CGFBoard.gd
@@ -59,8 +59,9 @@ func reshuffle_all_in_pile(pile: Pile = cfc.NMAP.deck):
 			await get_tree().create_timer(0.1).timeout
 	# Last card in, is the top card of the pile
 	var last_card : Card = pile.get_top_card()
-	if last_card._tween and last_card._tween.is_running():
-		await last_card._tween.finished
+	var tween : Tween = last_card._tween.get_object()
+	if tween.is_running():
+		await tween.finished
 	await get_tree().create_timer(0.2).timeout
 	pile.shuffle_cards()
 


### PR DESCRIPTION
CardTemplate's _tween is a WeakRef and not a Tween.

I think this should address this note in #1:
> Tween logic did work and then stopped working. tween_property().from() doesn't seem to like the weakref implementation.

However, card layout is still totally messed up (in Godot 4.3):
![image](https://github.com/user-attachments/assets/f4d784ec-1f13-4948-8a5c-bcdb0b46790e)



